### PR TITLE
Add reference linking bundle plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.2', '8.3']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+      - run: composer install --prefer-dist
+      - run: vendor/bin/phpstan analyse --no-progress
+      - run: vendor/bin/phpunit
+      - run: vendor/bin/phpcs --standard=PSR12 src tests

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# TradePro-References
+# sylius-reference-linking
+
+Sylius-Bundle zur konfigurierbaren Aufl\u00f6sung von Referenzlinks auf Variationsgruppen oder konkrete Varianten.
+
+## Problem & Herausforderung
+
+Variationsgruppen k\u00f6nnen bis zu 2'000 Varianten enthalten. Eine artikelweise Pflege von Referenzen ist teuer und fehleranf\u00e4llig. Falsch gesetzte Links f\u00fchren zu UX-Br\u00fcchen, Duplicate Content und schlechterer SEO.
+
+## Ziel
+
+Referenzen sollen gruppenbasiert gepflegt werden, Artikel-scharf nur wenn notwendig. Damit sinkt der Pflegeaufwand drastisch und die Datenqualit\u00e4t steigt.
+
+## Kundennutzen
+
+* **Kostenersparnis:** einmalige Pflege auf Gruppenebene statt tausendfach pro Variante.
+* **Datenqualit\u00e4t:** konsistente Referenzen f\u00fcr alle Varianten.
+* **SEO & Conversion:** kanonische Gruppen-URLs und stabile Navigationspfade.
+* **Risiko-Reduktion:** weniger 404-Links bei Variantenlebenszyklus.
+
+## Funktionsumfang
+
+* Policy pro Referenztyp (`required_accessory`, `optional_accessory`, `spare_part`, `matching`).
+* API zum Aufl\u00f6sen einzelner oder mehrerer SKUs.
+* Twig-Helper `reference_url(type, sku)`.
+* Produktseite tolerant f\u00fcr `?artnr=` Parameter und setzt `rel="canonical"`.
+* Einfache Admin-UI zur Bearbeitung der Policies.
+
+## Installation
+
+```bash
+composer require acme/sylius-reference-linking
+bin/console doctrine:migrations:migrate
+bin/console doctrine:fixtures:load --no-interaction
+```
+
+F\u00fcr lokale Entwicklung steht ein Docker-Setup zur Verf\u00fcgung:
+
+```bash
+make install
+make fixtures
+make up # docker-compose up -d
+```
+
+## Konfiguration
+
+Referenztypen k\u00f6nnen in `ReferenceUrlResolver::REFERENCE_TYPES` erweitert werden. Standard-Policies lassen sich \u00fcber Fixtures oder direkt in der Datenbank anpassen.
+
+## Nutzung
+
+### Twig
+
+```twig
+<a href="{{ reference_url('required_accessory', variant.code) }}">Zubeh\u00f6r</a>
+```
+
+### JavaScript
+
+```html
+<a data-reference-type="required_accessory" data-sku="SKU1">Link</a>
+<script src="/bundles/reference-linking/reference-snippet.js"></script>
+```
+
+### API
+
+* `GET /api/references/resolve?type=required_accessory&sku=SKU1`
+* `POST /api/references/resolve-batch` mit Body `{"type":"required_accessory","skus":["SKU1"]}`
+
+Antwort:
+
+```json
+{ "type": "required_accessory", "results": { "SKU1": "/de_CH/products/ABC" } }
+```
+
+## Sicherheit
+
+Admin-Routen liegen hinter der Sylius-Admin-Firewall und erfordern `ROLE_ADMIN`.
+
+## Tests & Qualit\u00e4t
+
+```bash
+make test
+```
+
+CI-Status: siehe GitHub Actions.
+
+## Lizenz
+
+MIT

--- a/sylius-reference-linking/Makefile
+++ b/sylius-reference-linking/Makefile
@@ -1,0 +1,11 @@
+install:
+	composer install
+
+test:
+	vendor/bin/phpunit
+
+cs-fix:
+	vendor/bin/phpcs --standard=PSR12 src tests
+
+fixtures:
+	bin/console doctrine:fixtures:load --no-interaction

--- a/sylius-reference-linking/composer.json
+++ b/sylius-reference-linking/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "acme/sylius-reference-linking",
+    "type": "symfony-bundle",
+    "description": "Sylius bundle plugin for reference linking",
+    "require": {
+        "php": "^8.2",
+        "symfony/framework-bundle": "^6.3",
+        "sylius/sylius": "^1.12",
+        "doctrine/orm": "^2.15",
+        "twig/twig": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Sylius\\ReferenceLinking\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sylius\\ReferenceLinking\\Tests\\": "tests/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0",
+        "phpstan/phpstan": "^1.10",
+        "squizlabs/php_codesniffer": "^3.7"
+    }
+}

--- a/sylius-reference-linking/docker-compose.yml
+++ b/sylius-reference-linking/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: sylius
+      POSTGRES_USER: sylius
+      POSTGRES_PASSWORD: sylius
+  php:
+    image: php:8.2-fpm
+    working_dir: /app
+    volumes:
+      - ./:/app
+    depends_on:
+      - db
+  nginx:
+    image: nginx:1.25
+    ports:
+      - '8080:80'
+    volumes:
+      - ./:/app
+      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - php

--- a/sylius-reference-linking/docker/nginx.conf
+++ b/sylius-reference-linking/docker/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    root /app/public;
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_pass php:9000;
+        fastcgi_param SCRIPT_FILENAME /app/public$fastcgi_script_name;
+    }
+}

--- a/sylius-reference-linking/fixtures/ReferenceLinkingPolicyFixtures.php
+++ b/sylius-reference-linking/fixtures/ReferenceLinkingPolicyFixtures.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Fixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Sylius\ReferenceLinking\Entity\ReferenceLinkingPolicy;
+
+final class ReferenceLinkingPolicyFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $defaults = [
+            'required_accessory' => ReferenceLinkingPolicy::TARGET_GROUP,
+            'optional_accessory' => ReferenceLinkingPolicy::TARGET_GROUP,
+            'spare_part' => ReferenceLinkingPolicy::TARGET_VARIANT,
+            'matching' => ReferenceLinkingPolicy::TARGET_GROUP,
+        ];
+
+        foreach ($defaults as $type => $target) {
+            $manager->persist(new ReferenceLinkingPolicy($type, $target));
+        }
+
+        $manager->flush();
+    }
+}
+

--- a/sylius-reference-linking/migrations/Version20250101000000.php
+++ b/sylius-reference-linking/migrations/Version20250101000000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\ReferenceLinking\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250101000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create app_reference_linking_policy table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('app_reference_linking_policy');
+        $table->addColumn('reference_type', 'string', ['length' => 64]);
+        $table->addColumn('target_level', 'string', ['length' => 10]);
+        $table->setPrimaryKey(['reference_type']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('app_reference_linking_policy');
+    }
+}
+

--- a/sylius-reference-linking/phpcs.xml
+++ b/sylius-reference-linking/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="ReferenceLinking">
+    <rule ref="PSR12"/>
+    <file>src</file>
+    <file>tests</file>
+</ruleset>

--- a/sylius-reference-linking/phpstan.neon
+++ b/sylius-reference-linking/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src
+        - tests

--- a/sylius-reference-linking/phpunit.xml.dist
+++ b/sylius-reference-linking/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="ReferenceLinking">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/sylius-reference-linking/src/Controller/Admin/ReferenceLinkingPolicyController.php
+++ b/sylius-reference-linking/src/Controller/Admin/ReferenceLinkingPolicyController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Controller\Admin;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\ReferenceLinking\Entity\ReferenceLinkingPolicy;
+use Sylius\ReferenceLinking\Form\Type\ReferenceLinkingPolicyType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/admin/reference-linking')]
+final class ReferenceLinkingPolicyController extends AbstractController
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    #[Route(path: '', name: 'app_admin_reference_linking_index')]
+    public function index(): Response
+    {
+        $policies = $this->entityManager->getRepository(ReferenceLinkingPolicy::class)->findAll();
+        return $this->render('admin/reference_linking/index.html.twig', [
+            'policies' => $policies,
+        ]);
+    }
+
+    #[Route(path: '/{referenceType}', name: 'app_admin_reference_linking_edit')]
+    public function edit(Request $request, string $referenceType): Response
+    {
+        $policy = $this->entityManager->find(ReferenceLinkingPolicy::class, $referenceType);
+        if (!$policy) {
+            throw $this->createNotFoundException();
+        }
+
+        $form = $this->createForm(ReferenceLinkingPolicyType::class, $policy);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->entityManager->flush();
+            return $this->redirectToRoute('app_admin_reference_linking_index');
+        }
+
+        return $this->render('admin/reference_linking/edit.html.twig', [
+            'form' => $form->createView(),
+            'policy' => $policy,
+        ]);
+    }
+}
+

--- a/sylius-reference-linking/src/Controller/Api/ReferenceUrlController.php
+++ b/sylius-reference-linking/src/Controller/Api/ReferenceUrlController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Controller\Api;
+
+use Sylius\ReferenceLinking\Service\ReferenceUrlResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/references')]
+final class ReferenceUrlController extends AbstractController
+{
+    public function __construct(private ReferenceUrlResolver $resolver)
+    {
+    }
+
+    #[Route(path: '/resolve', methods: ['GET'])]
+    public function resolveAction(Request $request): JsonResponse
+    {
+        $type = (string) $request->query->get('type');
+        $sku = (string) $request->query->get('sku');
+        $url = $this->resolver->resolveUrl($type, $sku);
+
+        return $this->json([
+            'sku' => $sku,
+            'type' => $type,
+            'url' => $url,
+        ]);
+    }
+
+    #[Route(path: '/resolve-batch', methods: ['POST'])]
+    public function resolveBatchAction(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true) ?? [];
+        $type = (string) ($data['type'] ?? '');
+        $skus = $data['skus'] ?? [];
+
+        $results = $this->resolver->resolveUrls($type, $skus);
+
+        return $this->json([
+            'type' => $type,
+            'results' => $results,
+        ]);
+    }
+}
+

--- a/sylius-reference-linking/src/Controller/Product/ShowController.php
+++ b/sylius-reference-linking/src/Controller/Product/ShowController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Controller\Product;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/{_locale}/products/{code}', requirements: ['_locale' => 'de_CH|de_DE|en_GB|fr_CH'], name: 'sylius_shop_product_show')]
+final class ShowController extends AbstractController
+{
+    public function __invoke(Request $request, string $_locale, string $code): Response
+    {
+        $response = $this->render('product/show.html.twig', [
+            'code' => $code,
+            'variant' => $request->query->get('artnr'),
+        ]);
+
+        $canonical = sprintf('/%s/products/%s', $_locale, $code);
+        $response->headers->set('Link', sprintf('<%s>; rel="canonical"', $canonical));
+
+        return $response;
+    }
+}
+

--- a/sylius-reference-linking/src/DependencyInjection/ReferenceLinkingExtension.php
+++ b/sylius-reference-linking/src/DependencyInjection/ReferenceLinkingExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sylius\ReferenceLinking\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Config\FileLocator;
+
+final class ReferenceLinkingExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yaml');
+    }
+}
+

--- a/sylius-reference-linking/src/Entity/ReferenceLinkingPolicy.php
+++ b/sylius-reference-linking/src/Entity/ReferenceLinkingPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'app_reference_linking_policy')]
+class ReferenceLinkingPolicy
+{
+    public const TARGET_GROUP = 'group';
+    public const TARGET_VARIANT = 'variant';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'string', length: 64)]
+    private string $referenceType;
+
+    #[ORM\Column(type: 'string', length: 10)]
+    private string $targetLevel = self::TARGET_GROUP;
+
+    public function __construct(string $referenceType, string $targetLevel)
+    {
+        $this->referenceType = $referenceType;
+        $this->targetLevel = $targetLevel;
+    }
+
+    public function getReferenceType(): string
+    {
+        return $this->referenceType;
+    }
+
+    public function getTargetLevel(): string
+    {
+        return $this->targetLevel;
+    }
+
+    public function setTargetLevel(string $targetLevel): void
+    {
+        $this->targetLevel = $targetLevel;
+    }
+}
+

--- a/sylius-reference-linking/src/Form/Type/ReferenceLinkingPolicyType.php
+++ b/sylius-reference-linking/src/Form/Type/ReferenceLinkingPolicyType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Form\Type;
+
+use Sylius\ReferenceLinking\Entity\ReferenceLinkingPolicy;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ReferenceLinkingPolicyType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('referenceType', HiddenType::class)
+            ->add('targetLevel', ChoiceType::class, [
+                'choices' => [
+                    'Variationsgruppe' => ReferenceLinkingPolicy::TARGET_GROUP,
+                    'Variante' => ReferenceLinkingPolicy::TARGET_VARIANT,
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ReferenceLinkingPolicy::class,
+        ]);
+    }
+}
+

--- a/sylius-reference-linking/src/ReferenceLinkingBundle.php
+++ b/sylius-reference-linking/src/ReferenceLinkingBundle.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sylius\ReferenceLinking;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class ReferenceLinkingBundle extends Bundle
+{
+}
+

--- a/sylius-reference-linking/src/Resources/config/routes.yaml
+++ b/sylius-reference-linking/src/Resources/config/routes.yaml
@@ -1,0 +1,3 @@
+reference_linking:
+    resource: '../../src/Controller/'
+    type: attribute

--- a/sylius-reference-linking/src/Resources/config/security_admin_notes.md
+++ b/sylius-reference-linking/src/Resources/config/security_admin_notes.md
@@ -1,0 +1,1 @@
+Alle Admin-Routen befinden sich hinter der Sylius-Admin-Firewall und sind nur f\u00fcr Benutzer mit Rolle ROLE_ADMIN zug\u00e4nglich.

--- a/sylius-reference-linking/src/Resources/config/services.yaml
+++ b/sylius-reference-linking/src/Resources/config/services.yaml
@@ -1,0 +1,9 @@
+services:
+    Sylius\ReferenceLinking\:
+        resource: '../../*'
+        exclude: '../../{DependencyInjection,Entity,Tests}'
+    Sylius\ReferenceLinking\Controller\:
+        resource: '../../Controller'
+        tags: ['controller.service_arguments']
+    Sylius\ReferenceLinking\Twig\ReferenceUrlExtension:
+        tags: ['twig.extension']

--- a/sylius-reference-linking/src/Service/ReferenceUrlResolver.php
+++ b/sylius-reference-linking/src/Service/ReferenceUrlResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\ReferenceLinking\Entity\ReferenceLinkingPolicy;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
+
+final class ReferenceUrlResolver
+{
+    public const REFERENCE_TYPES = ["required_accessory","optional_accessory","spare_part","matching"];
+
+    private ProductVariantRepositoryInterface $variantRepository;
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(
+        ProductVariantRepositoryInterface $variantRepository,
+        EntityManagerInterface $entityManager
+    ) {
+        $this->variantRepository = $variantRepository;
+        $this->entityManager = $entityManager;
+    }
+
+    public function resolveUrl(string $referenceType, string $variantCode): ?string
+    {
+        /** @var ProductVariantInterface|null $variant */
+        $variant = $this->variantRepository->findOneBy(['code' => $variantCode]);
+        if ($variant === null) {
+            return null;
+        }
+
+        $product = $variant->getProduct();
+        $policy = $this->entityManager->find(ReferenceLinkingPolicy::class, $referenceType);
+        $target = $policy?->getTargetLevel() ?? ReferenceLinkingPolicy::TARGET_GROUP;
+
+        $code = $product->getCode();
+        if ($target === ReferenceLinkingPolicy::TARGET_GROUP) {
+            return sprintf('/de_CH/products/%s', $code);
+        }
+
+        return sprintf('/de_CH/products/%s?artnr=%s', $code, $variantCode);
+    }
+
+    /**
+     * @param string[] $variantCodes
+     * @return array<string,string|null>
+     */
+    public function resolveUrls(string $referenceType, array $variantCodes): array
+    {
+        $results = [];
+        foreach ($variantCodes as $code) {
+            $results[$code] = $this->resolveUrl($referenceType, $code);
+        }
+
+        return $results;
+    }
+}
+

--- a/sylius-reference-linking/src/Twig/ReferenceUrlExtension.php
+++ b/sylius-reference-linking/src/Twig/ReferenceUrlExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Twig;
+
+use Sylius\ReferenceLinking\Service\ReferenceUrlResolver;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class ReferenceUrlExtension extends AbstractExtension
+{
+    public function __construct(private ReferenceUrlResolver $resolver)
+    {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('reference_url', [$this, 'referenceUrl']),
+        ];
+    }
+
+    public function referenceUrl(string $type, string $sku): ?string
+    {
+        return $this->resolver->resolveUrl($type, $sku);
+    }
+}
+

--- a/sylius-reference-linking/templates/admin/reference_linking/edit.html.twig
+++ b/sylius-reference-linking/templates/admin/reference_linking/edit.html.twig
@@ -1,0 +1,5 @@
+<h1>Policy bearbeiten: {{ policy.referenceType }}</h1>
+{{ form_start(form) }}
+{{ form_widget(form) }}
+<button type="submit">Speichern</button>
+{{ form_end(form) }}

--- a/sylius-reference-linking/templates/admin/reference_linking/index.html.twig
+++ b/sylius-reference-linking/templates/admin/reference_linking/index.html.twig
@@ -1,0 +1,11 @@
+<h1>Reference Linking Policies</h1>
+<table>
+  <tr><th>Typ</th><th>Ziel</th><th></th></tr>
+  {% for policy in policies %}
+  <tr>
+    <td>{{ policy.referenceType }}</td>
+    <td>{{ policy.targetLevel }}</td>
+    <td><a href="{{ path('app_admin_reference_linking_edit', {referenceType: policy.referenceType}) }}">Bearbeiten</a></td>
+  </tr>
+  {% endfor %}
+</table>

--- a/sylius-reference-linking/templates/product/show.html.twig
+++ b/sylius-reference-linking/templates/product/show.html.twig
@@ -1,0 +1,4 @@
+<h1>Produkt {{ code }}</h1>
+{% if variant %}
+<p>Variante: {{ variant }}</p>
+{% endif %}

--- a/sylius-reference-linking/templates/reference-snippet.js
+++ b/sylius-reference-linking/templates/reference-snippet.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const elements = document.querySelectorAll('[data-reference-type][data-sku]');
+  if (elements.length === 0) return;
+  const type = elements[0].dataset.referenceType;
+  const skus = Array.from(elements).map(el => el.dataset.sku);
+  fetch('/api/references/resolve-batch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, skus })
+  }).then(r => r.json()).then(data => {
+    for (const el of elements) {
+      const url = data.results[el.dataset.sku];
+      if (url) {
+        el.setAttribute('href', url);
+      }
+    }
+  });
+});

--- a/sylius-reference-linking/tests/Controller/Api/ReferenceUrlControllerTest.php
+++ b/sylius-reference-linking/tests/Controller/Api/ReferenceUrlControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Tests\Controller\Api;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\ReferenceLinking\Controller\Api\ReferenceUrlController;
+use Sylius\ReferenceLinking\Service\ReferenceUrlResolver;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ReferenceUrlControllerTest extends TestCase
+{
+    public function testResolveAction(): void
+    {
+        $resolver = $this->createMock(ReferenceUrlResolver::class);
+        $resolver->method('resolveUrl')->willReturn('/foo');
+        $controller = new ReferenceUrlController($resolver);
+        $request = new Request(['type' => 't', 'sku' => 's']);
+        $response = $controller->resolveAction($request);
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame('/foo', $data['url']);
+    }
+
+    public function testResolveBatchAction(): void
+    {
+        $resolver = $this->createMock(ReferenceUrlResolver::class);
+        $resolver->method('resolveUrls')->willReturn(['a' => '/a', 'b' => null]);
+        $controller = new ReferenceUrlController($resolver);
+        $request = new Request([], [], [], [], [], [], json_encode(['type' => 'x', 'skus' => ['a','b']]));
+        $response = $controller->resolveBatchAction($request);
+        $data = json_decode($response->getContent(), true);
+        $this->assertSame('/a', $data['results']['a']);
+        $this->assertArrayHasKey('b', $data['results']);
+    }
+}
+

--- a/sylius-reference-linking/tests/Controller/Product/ShowControllerTest.php
+++ b/sylius-reference-linking/tests/Controller/Product/ShowControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Tests\Controller\Product;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\ReferenceLinking\Controller\Product\ShowController;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ShowControllerTest extends TestCase
+{
+    public function testSetsCanonicalHeader(): void
+    {
+        $controller = new ShowController();
+        $request = new Request(['artnr' => 'SKU1']);
+        $response = $controller($request, 'de_CH', 'GROUP1');
+        $this->assertTrue($response->headers->has('Link'));
+        $this->assertStringContainsString('/de_CH/products/GROUP1', $response->headers->get('Link'));
+    }
+}
+

--- a/sylius-reference-linking/tests/Service/ReferenceUrlResolverTest.php
+++ b/sylius-reference-linking/tests/Service/ReferenceUrlResolverTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sylius\ReferenceLinking\Tests\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Sylius\ReferenceLinking\Entity\ReferenceLinkingPolicy;
+use Sylius\ReferenceLinking\Service\ReferenceUrlResolver;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
+
+final class ReferenceUrlResolverTest extends TestCase
+{
+    public function testResolvesGroupUrl(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getCode')->willReturn('GROUP1');
+
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $variant->method('getProduct')->willReturn($product);
+
+        $variantRepository = $this->createMock(ProductVariantRepositoryInterface::class);
+        $variantRepository->method('findOneBy')->with(['code' => 'SKU1'])->willReturn($variant);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturn(new ReferenceLinkingPolicy('required_accessory', ReferenceLinkingPolicy::TARGET_GROUP));
+
+        $resolver = new ReferenceUrlResolver($variantRepository, $entityManager);
+        $this->assertSame('/de_CH/products/GROUP1', $resolver->resolveUrl('required_accessory', 'SKU1'));
+    }
+
+    public function testResolvesVariantUrl(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getCode')->willReturn('GROUP2');
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $variant->method('getProduct')->willReturn($product);
+        $variantRepository = $this->createMock(ProductVariantRepositoryInterface::class);
+        $variantRepository->method('findOneBy')->willReturn($variant);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('find')->willReturn(new ReferenceLinkingPolicy('spare_part', ReferenceLinkingPolicy::TARGET_VARIANT));
+        $resolver = new ReferenceUrlResolver($variantRepository, $entityManager);
+        $this->assertSame('/de_CH/products/GROUP2?artnr=SKU2', $resolver->resolveUrl('spare_part', 'SKU2'));
+    }
+
+    public function testReturnsNullWhenVariantMissing(): void
+    {
+        $variantRepository = $this->createMock(ProductVariantRepositoryInterface::class);
+        $variantRepository->method('findOneBy')->willReturn(null);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $resolver = new ReferenceUrlResolver($variantRepository, $entityManager);
+        $this->assertNull($resolver->resolveUrl('required_accessory', 'UNKNOWN'));
+    }
+}
+

--- a/sylius-reference-linking/tests/bootstrap.php
+++ b/sylius-reference-linking/tests/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+require __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- implement reference linking policy entity and migration
- provide URL resolver, Twig extension, API endpoints and admin UI
- add tests, fixtures, Docker setup, Makefile and CI workflow

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `vendor/bin/phpstan analyse --no-progress` *(fails: No such file or directory)*
- `vendor/bin/phpcs --standard=PSR12 src tests` *(fails: No such file or directory)*
- `bin/console doctrine:fixtures:load --no-interaction` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c143ef0b88322908432ee34b080ff